### PR TITLE
feat: view my lists link

### DIFF
--- a/apps/web/public/dictionaries/de-DE.json
+++ b/apps/web/public/dictionaries/de-DE.json
@@ -289,7 +289,8 @@
   "list_page": {
     "list_not_found": "Liste nicht gefunden.",
     "see_your_lists_or_create_new": "Sieh dir deine Listen an oder erstelle eine neue, indem du klickst",
-    "here": "hier"
+    "here": "hier",
+    "list_view_link": "Listen anzeigen"
   },
   "list_items": {
     "table": "Tabelle",

--- a/apps/web/public/dictionaries/de-DE.json
+++ b/apps/web/public/dictionaries/de-DE.json
@@ -289,8 +289,7 @@
   "list_page": {
     "list_not_found": "Liste nicht gefunden.",
     "see_your_lists_or_create_new": "Sieh dir deine Listen an oder erstelle eine neue, indem du klickst",
-    "here": "hier",
-    "list_view_link": "Listen anzeigen"
+    "here": "hier"
   },
   "list_items": {
     "table": "Tabelle",
@@ -686,5 +685,6 @@
   "right_click_here": "Hier rechtsklicken",
   "list_cloned_successfully": "Liste erfolgreich geklont!",
   "see_list": "Liste anzeigen",
-  "unable_to_clone_list": "Liste konnte nicht geklont werden."
+  "unable_to_clone_list": "Liste konnte nicht geklont werden.",
+  "see_all_list": "Alles anzeigen"
 }

--- a/apps/web/public/dictionaries/en-US.json
+++ b/apps/web/public/dictionaries/en-US.json
@@ -289,8 +289,7 @@
   "list_page": {
     "list_not_found": "List not found.",
     "see_your_lists_or_create_new": "See your lists or create new clicking",
-    "here": "here",
-    "list_view_link": "View lists"
+    "here": "here"
   },
   "list_items": {
     "table": "Table",
@@ -687,5 +686,6 @@
   "right_click_here": "Right Click Here",
   "list_cloned_successfully": "List cloned successfully!",
   "see_list": "See list",
-  "unable_to_clone_list": "Unable to clone list."
+  "unable_to_clone_list": "Unable to clone list.",
+  "see_all_list": "See all"
 }

--- a/apps/web/public/dictionaries/en-US.json
+++ b/apps/web/public/dictionaries/en-US.json
@@ -289,7 +289,8 @@
   "list_page": {
     "list_not_found": "List not found.",
     "see_your_lists_or_create_new": "See your lists or create new clicking",
-    "here": "here"
+    "here": "here",
+    "list_view_link": "View lists"
   },
   "list_items": {
     "table": "Table",

--- a/apps/web/public/dictionaries/es-ES.json
+++ b/apps/web/public/dictionaries/es-ES.json
@@ -289,8 +289,7 @@
   "list_page": {
     "list_not_found": "Lista no encontrada.",
     "see_your_lists_or_create_new": "Consulta tus listas o crea una nueva haciendo clic",
-    "here": "aquí",
-    "list_view_link": "Ver listas"
+    "here": "aquí"
   },
   "list_items": {
     "table": "Tabla",
@@ -686,5 +685,6 @@
   "right_click_here": "Haga clic derecho aquí",
   "list_cloned_successfully": "¡Lista clonada con éxito!",
   "see_list": "Ver lista",
-  "unable_to_clone_list": "No se pudo clonar la lista."
+  "unable_to_clone_list": "No se pudo clonar la lista.",
+  "see_all_list": "Ver todo"
 }

--- a/apps/web/public/dictionaries/es-ES.json
+++ b/apps/web/public/dictionaries/es-ES.json
@@ -289,7 +289,8 @@
   "list_page": {
     "list_not_found": "Lista no encontrada.",
     "see_your_lists_or_create_new": "Consulta tus listas o crea una nueva haciendo clic",
-    "here": "aquí"
+    "here": "aquí",
+    "list_view_link": "Ver listas"
   },
   "list_items": {
     "table": "Tabla",

--- a/apps/web/public/dictionaries/fr-FR.json
+++ b/apps/web/public/dictionaries/fr-FR.json
@@ -290,7 +290,8 @@
   "list_page": {
     "list_not_found": "Liste non trouvée.",
     "see_your_lists_or_create_new": "Voir vos listes ou en créer une nouvelle en cliquant",
-    "here": "ici"
+    "here": "ici",
+    "list_view_link": "Voir les listes"
   },
   "list_items": {
     "table": "Tableau",

--- a/apps/web/public/dictionaries/fr-FR.json
+++ b/apps/web/public/dictionaries/fr-FR.json
@@ -290,8 +290,7 @@
   "list_page": {
     "list_not_found": "Liste non trouvée.",
     "see_your_lists_or_create_new": "Voir vos listes ou en créer une nouvelle en cliquant",
-    "here": "ici",
-    "list_view_link": "Voir les listes"
+    "here": "ici"
   },
   "list_items": {
     "table": "Tableau",
@@ -687,5 +686,6 @@
   "right_click_here": "Cliquez droit ici",
   "list_cloned_successfully": "Liste clonée avec succès!",
   "see_list": "Voir la liste",
-  "unable_to_clone_list": "Impossible de cloner la liste."
+  "unable_to_clone_list": "Impossible de cloner la liste.",
+  "see_all_list": "Voir tout"
 }

--- a/apps/web/public/dictionaries/it-IT.json
+++ b/apps/web/public/dictionaries/it-IT.json
@@ -290,8 +290,7 @@
   "list_page": {
     "list_not_found": "Lista non trovata.",
     "see_your_lists_or_create_new": "Visualizza le tue liste o crea una nuova cliccando",
-    "here": "qui",
-    "list_view_link": "Visualizza liste"
+    "here": "qui"
   },
   "list_items": {
     "table": "Tabella",
@@ -687,5 +686,6 @@
   "right_click_here": "Clicca con il tasto destro qui",
   "list_cloned_successfully": "Lista clonata con successo!",
   "see_list": "Vedi lista",
-  "unable_to_clone_list": "Impossibile clonare la lista."
+  "unable_to_clone_list": "Impossibile clonare la lista.",
+  "see_all_list": "Vedi tutto"
 }

--- a/apps/web/public/dictionaries/it-IT.json
+++ b/apps/web/public/dictionaries/it-IT.json
@@ -290,7 +290,8 @@
   "list_page": {
     "list_not_found": "Lista non trovata.",
     "see_your_lists_or_create_new": "Visualizza le tue liste o crea una nuova cliccando",
-    "here": "qui"
+    "here": "qui",
+    "list_view_link": "Visualizza liste"
   },
   "list_items": {
     "table": "Tabella",

--- a/apps/web/public/dictionaries/ja-JP.json
+++ b/apps/web/public/dictionaries/ja-JP.json
@@ -289,7 +289,8 @@
   "list_page": {
     "list_not_found": "リストが見つかりませんでした。",
     "see_your_lists_or_create_new": "リストを見るか、ここをクリックして新しいリストを作成する",
-    "here": "ここ"
+    "here": "ここ",
+    "list_view_link": "リストを見る"
   },
   "list_items": {
     "table": "テーブル",

--- a/apps/web/public/dictionaries/ja-JP.json
+++ b/apps/web/public/dictionaries/ja-JP.json
@@ -289,8 +289,7 @@
   "list_page": {
     "list_not_found": "リストが見つかりませんでした。",
     "see_your_lists_or_create_new": "リストを見るか、ここをクリックして新しいリストを作成する",
-    "here": "ここ",
-    "list_view_link": "リストを見る"
+    "here": "ここ"
   },
   "list_items": {
     "table": "テーブル",
@@ -686,5 +685,6 @@
   "right_click_here": "ここを右クリック",
   "list_cloned_successfully": "リストを成功裏にクローンしました！",
   "see_list": "リストを見る",
-  "unable_to_clone_list": "リストをクローンできませんでした。"
+  "unable_to_clone_list": "リストをクローンできませんでした。",
+  "see_all_list": "すべてを見る"
 }

--- a/apps/web/public/dictionaries/pt-BR.json
+++ b/apps/web/public/dictionaries/pt-BR.json
@@ -289,7 +289,8 @@
   "list_page": {
     "list_not_found": "Lista não encontrada.",
     "see_your_lists_or_create_new": "Veja suas listas ou crie uma nova clicando",
-    "here": "aqui"
+    "here": "aqui",
+    "list_view_link": "Ver listas"
   },
   "list_items": {
     "table": "Tabela",

--- a/apps/web/public/dictionaries/pt-BR.json
+++ b/apps/web/public/dictionaries/pt-BR.json
@@ -289,8 +289,7 @@
   "list_page": {
     "list_not_found": "Lista não encontrada.",
     "see_your_lists_or_create_new": "Veja suas listas ou crie uma nova clicando",
-    "here": "aqui",
-    "list_view_link": "Ver listas"
+    "here": "aqui"
   },
   "list_items": {
     "table": "Tabela",
@@ -687,5 +686,7 @@
   "right_click_here": "Clique com o botão direito",
   "list_cloned_successfully": "Lista clonada com sucesso!",
   "see_list": "Ver lista",
-  "unable_to_clone_list": "Não foi possível clonar a lista."
+  "unable_to_clone_list": "Não foi possível clonar a lista.",
+  "see_all_list": "Ver tudo"
+
 }

--- a/apps/web/src/app/[lang]/[username]/_components/profile-reviews.tsx
+++ b/apps/web/src/app/[lang]/[username]/_components/profile-reviews.tsx
@@ -1,19 +1,14 @@
 import { FullReview } from '@/components/full-review'
-import { getProfileReviews } from '@/services/api/profiles'
 import { Language } from '@/types/languages'
 import { EmptyReview } from '../../_components/user-last-review'
+import { FullReview as FullReviewType } from '@/services/api/reviews'
 
 type ProfileReviewsProps = {
-  userId: string
+  reviews: FullReviewType[]
   language: Language
 }
 
-export const ProfileReviews = async ({
-  userId,
-  language,
-}: ProfileReviewsProps) => {
-  const reviews = await getProfileReviews({ userId, language })
-
+export const ProfileReviews = ({ reviews, language }: ProfileReviewsProps) => {
   return (
     <div className="space-y-4">
       {reviews.length > 0 ? (

--- a/apps/web/src/app/[lang]/[username]/_components/profile-tabs.tsx
+++ b/apps/web/src/app/[lang]/[username]/_components/profile-tabs.tsx
@@ -4,12 +4,11 @@ import { Award, List, Star, Users } from 'lucide-react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { ProfileReviews } from './profile-reviews'
 import { ProfileLists } from './profile-lists'
-import { Dictionary } from '@/utils/dictionaries'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Profile } from '@/types/supabase'
-import { Language } from '@/types/languages'
 import { FullReview } from '@/services/api/reviews'
 import dynamic from 'next/dynamic'
+import { useLanguage } from '@/context/language'
 
 const ProfileAchievements = dynamic(
   () => import('./profile-achievements').then((mod) => mod.ProfileAchievements),
@@ -17,20 +16,14 @@ const ProfileAchievements = dynamic(
 )
 
 type ProfileTabsProps = {
-  dictionary: Dictionary
   profile: Profile
-  lang: Language
   reviews: FullReview[]
 }
 
-export const ProfileTabs = ({
-  dictionary,
-  profile,
-  lang,
-  reviews,
-}: ProfileTabsProps) => {
+export const ProfileTabs = ({ profile, reviews }: ProfileTabsProps) => {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const { language, dictionary } = useLanguage()
 
   const tab = searchParams.get('tab') ?? 'reviews'
 
@@ -76,7 +69,7 @@ export const ProfileTabs = ({
       </div>
 
       <TabsContent value="reviews" className="mt-4">
-        <ProfileReviews reviews={reviews} language={lang} />
+        <ProfileReviews reviews={reviews} language={language} />
       </TabsContent>
 
       <TabsContent value="lists" className="mt-4">

--- a/apps/web/src/app/[lang]/[username]/_components/profile-tabs.tsx
+++ b/apps/web/src/app/[lang]/[username]/_components/profile-tabs.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { Award, List, Star, Users } from 'lucide-react'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { ProfileReviews } from './profile-reviews'
+import { ProfileLists } from './profile-lists'
+import { Dictionary } from '@/utils/dictionaries'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { Profile } from '@/types/supabase'
+import { Language } from '@/types/languages'
+import { FullReview } from '@/services/api/reviews'
+import dynamic from 'next/dynamic'
+
+const ProfileAchievements = dynamic(
+  () => import('./profile-achievements').then((mod) => mod.ProfileAchievements),
+  { ssr: false },
+)
+
+type ProfileTabsProps = {
+  dictionary: Dictionary
+  profile: Profile
+  lang: Language
+  reviews: FullReview[]
+}
+
+export const ProfileTabs = ({
+  dictionary,
+  profile,
+  lang,
+  reviews,
+}: ProfileTabsProps) => {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const tab = searchParams.get('tab') ?? 'reviews'
+
+  function handleTabChange(tab: string) {
+    router.replace(`?tab=${tab}`, { scroll: false })
+  }
+
+  return (
+    <Tabs defaultValue="reviews" value={tab} className="w-full">
+      <div className="md:m-none p-none -mx-4 max-w-[100vw] overflow-x-scroll px-4 scrollbar-hide">
+        <TabsList>
+          <TabsTrigger
+            onClick={() => handleTabChange('reviews')}
+            value="reviews"
+          >
+            <Star className="mr-1" width={12} height={12} />
+            {dictionary.profile.reviews}
+          </TabsTrigger>
+
+          <TabsTrigger onClick={() => handleTabChange('lists')} value="lists">
+            <List className="mr-1" width={12} height={12} />
+            {dictionary.profile.lists}
+          </TabsTrigger>
+
+          <TabsTrigger
+            onClick={() => handleTabChange('achievements')}
+            value="achievements"
+          >
+            <Award className="mr-1" width={12} height={12} />
+            {dictionary.profile.achievements}
+          </TabsTrigger>
+
+          <TabsTrigger
+            onClick={() => handleTabChange('communities')}
+            value="communities"
+            disabled
+          >
+            <Users className="mr-1" width={12} height={12} />
+
+            {dictionary.profile.communities}
+          </TabsTrigger>
+        </TabsList>
+      </div>
+
+      <TabsContent value="reviews" className="mt-4">
+        <ProfileReviews reviews={reviews} language={lang} />
+      </TabsContent>
+
+      <TabsContent value="lists" className="mt-4">
+        <ProfileLists userId={profile.id} />
+      </TabsContent>
+
+      <TabsContent value="achievements" className="mt-4">
+        <ProfileAchievements dictionary={dictionary} />
+      </TabsContent>
+    </Tabs>
+  )
+}

--- a/apps/web/src/app/[lang]/[username]/page.tsx
+++ b/apps/web/src/app/[lang]/[username]/page.tsx
@@ -1,5 +1,4 @@
 import { redirect } from 'next/navigation'
-
 import { PageProps } from '@/types/languages'
 import { Pencil } from 'lucide-react'
 import {
@@ -8,7 +7,6 @@ import {
 } from '@/services/api/profiles'
 import { Button } from '@/components/ui/button'
 import { ProBadge } from '@/components/pro-badge'
-
 import { ProfileBanner } from './_components/profile-banner'
 import { ProfileForm } from './_components/profile-form'
 import { ProfileImage } from './_components/profile-image'

--- a/apps/web/src/app/[lang]/[username]/page.tsx
+++ b/apps/web/src/app/[lang]/[username]/page.tsx
@@ -1,23 +1,22 @@
 import { redirect } from 'next/navigation'
 
 import { PageProps } from '@/types/languages'
-import { Award, List, Pencil, Star, Users } from 'lucide-react'
-import { getProfileByUsername } from '@/services/api/profiles'
-
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Pencil } from 'lucide-react'
+import {
+  getProfileByUsername,
+  getProfileReviews,
+} from '@/services/api/profiles'
 import { Button } from '@/components/ui/button'
 import { ProBadge } from '@/components/pro-badge'
 
-import { ProfileReviews } from './_components/profile-reviews'
-import { ProfileLists } from './_components/profile-lists'
 import { ProfileBanner } from './_components/profile-banner'
 import { ProfileForm } from './_components/profile-form'
 import { ProfileImage } from './_components/profile-image'
-import { ProfileAchievements } from './_components/profile-achievements'
 
 import { getDictionary } from '@/utils/dictionaries'
+import { ProfileTabs } from './_components/profile-tabs'
 
-type UserPageProps = PageProps<Record<'username', string>>
+export type UserPageProps = PageProps<Record<'username', string>>
 
 const UserPage = async ({ params: { username, lang } }: UserPageProps) => {
   const profile = await getProfileByUsername(username)
@@ -26,6 +25,11 @@ const UserPage = async ({ params: { username, lang } }: UserPageProps) => {
   if (!profile) {
     redirect(`/${lang}/home`)
   }
+
+  const reviews = await getProfileReviews({
+    userId: profile.id,
+    language: lang,
+  })
 
   return (
     <main className="p-0 lg:p-4">
@@ -61,44 +65,12 @@ const UserPage = async ({ params: { username, lang } }: UserPageProps) => {
           </aside>
 
           <section>
-            <Tabs defaultValue="reviews" className="w-full">
-              <div className="md:m-none p-none -mx-4 max-w-[100vw] overflow-x-scroll px-4 scrollbar-hide">
-                <TabsList>
-                  <TabsTrigger value="reviews">
-                    <Star className="mr-1" width={12} height={12} />
-                    {dictionary.profile.reviews}
-                  </TabsTrigger>
-
-                  <TabsTrigger value="lists">
-                    <List className="mr-1" width={12} height={12} />
-                    {dictionary.profile.lists}
-                  </TabsTrigger>
-
-                  <TabsTrigger value="achievements">
-                    <Award className="mr-1" width={12} height={12} />
-                    {dictionary.profile.achievements}
-                  </TabsTrigger>
-
-                  <TabsTrigger value="communities" disabled>
-                    <Users className="mr-1" width={12} height={12} />
-
-                    {dictionary.profile.communities}
-                  </TabsTrigger>
-                </TabsList>
-              </div>
-
-              <TabsContent value="reviews" className="mt-4">
-                <ProfileReviews userId={profile.id} language={lang} />
-              </TabsContent>
-
-              <TabsContent value="lists" className="mt-4">
-                <ProfileLists userId={profile.id} />
-              </TabsContent>
-
-              <TabsContent value="achievements" className="mt-4">
-                <ProfileAchievements dictionary={dictionary} />
-              </TabsContent>
-            </Tabs>
+            <ProfileTabs
+              dictionary={dictionary}
+              lang={lang}
+              profile={profile}
+              reviews={reviews}
+            />
           </section>
         </div>
       </div>

--- a/apps/web/src/app/[lang]/[username]/page.tsx
+++ b/apps/web/src/app/[lang]/[username]/page.tsx
@@ -12,15 +12,12 @@ import { ProBadge } from '@/components/pro-badge'
 import { ProfileBanner } from './_components/profile-banner'
 import { ProfileForm } from './_components/profile-form'
 import { ProfileImage } from './_components/profile-image'
-
-import { getDictionary } from '@/utils/dictionaries'
 import { ProfileTabs } from './_components/profile-tabs'
 
 export type UserPageProps = PageProps<Record<'username', string>>
 
 const UserPage = async ({ params: { username, lang } }: UserPageProps) => {
   const profile = await getProfileByUsername(username)
-  const dictionary = await getDictionary(lang)
 
   if (!profile) {
     redirect(`/${lang}/home`)
@@ -65,12 +62,7 @@ const UserPage = async ({ params: { username, lang } }: UserPageProps) => {
           </aside>
 
           <section>
-            <ProfileTabs
-              dictionary={dictionary}
-              lang={lang}
-              profile={profile}
-              reviews={reviews}
-            />
+            <ProfileTabs profile={profile} reviews={reviews} />
           </section>
         </div>
       </div>

--- a/apps/web/src/app/[lang]/lists/[id]/_components/list-recommendations/list-recommendation.tsx
+++ b/apps/web/src/app/[lang]/lists/[id]/_components/list-recommendations/list-recommendation.tsx
@@ -75,7 +75,7 @@ export const ListRecommendation = ({ item, list }: ListRecommendationProps) => {
         <div className="absolute right-2 top-2">
           <DropdownMenu onOpenChange={setOpenDropdown} open={openDropdown}>
             <DropdownMenuTrigger>
-              <Button size="icon" variant="default" className="h-5 w-5 ">
+              <Button size="icon" variant="default" className="h-5 w-5">
                 <MoreVertical size={12} />
               </Button>
             </DropdownMenuTrigger>

--- a/apps/web/src/app/[lang]/lists/page.tsx
+++ b/apps/web/src/app/[lang]/lists/page.tsx
@@ -2,17 +2,17 @@ import { Metadata } from 'next'
 
 import { Lists } from './_components/lists'
 import { Container } from '../_components/container'
-
 import { PageProps } from '@/types/languages'
 import { getDictionary } from '@/utils/dictionaries'
 import { PopularLists } from './_components/popular-lists'
 import { Separator } from '@/components/ui/separator'
+import Link from 'next/link'
+import { getUserService } from '@/services/api/users/get-user'
 
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const dictionary = await getDictionary(params.lang)
-
   const title = dictionary.lists
   const description = dictionary.manage_your_lists
 
@@ -33,18 +33,26 @@ export async function generateMetadata({
 
 const ListsPage = async ({ params: { lang } }: PageProps) => {
   const dictionary = await getDictionary(lang)
+  const user = await getUserService()
 
   return (
     <Container>
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between ">
         <div>
           <h1 className="text-xl font-bold">{dictionary.my_lists}</h1>
           <p className="text-muted-foreground">
             {dictionary.manage_your_lists}
           </p>
         </div>
+        {user && (
+          <Link
+            href={`/${lang}/${user.username}?tab=lists`}
+            className="text-sm "
+          >
+            {dictionary.list_page.list_view_link}
+          </Link>
+        )}
       </div>
-
       <div className="space-y-8">
         <Lists />
         <Separator />

--- a/apps/web/src/app/[lang]/lists/page.tsx
+++ b/apps/web/src/app/[lang]/lists/page.tsx
@@ -37,7 +37,7 @@ const ListsPage = async ({ params: { lang } }: PageProps) => {
 
   return (
     <Container>
-      <div className="flex items-center justify-between ">
+      <div className="flex items-end justify-between ">
         <div>
           <h1 className="text-xl font-bold">{dictionary.my_lists}</h1>
           <p className="text-muted-foreground">
@@ -47,9 +47,9 @@ const ListsPage = async ({ params: { lang } }: PageProps) => {
         {user && (
           <Link
             href={`/${lang}/${user.username}?tab=lists`}
-            className="text-sm "
+            className="text-sm text-muted-foreground hover:underline"
           >
-            {dictionary.list_page.list_view_link}
+            {dictionary.see_all_list}
           </Link>
         )}
       </div>

--- a/apps/web/src/utils/dictionaries/get-dictionaries.types.ts
+++ b/apps/web/src/utils/dictionaries/get-dictionaries.types.ts
@@ -271,7 +271,6 @@ export type Dictionary = {
     list_not_found: string
     see_your_lists_or_create_new: string
     here: string
-    list_view_link: string
   }
   list_items: {
     table: string
@@ -674,4 +673,5 @@ export type Dictionary = {
   list_cloned_successfully: string
   see_list: string
   unable_to_clone_list: string
+  see_all_list: string
 }

--- a/apps/web/src/utils/dictionaries/get-dictionaries.types.ts
+++ b/apps/web/src/utils/dictionaries/get-dictionaries.types.ts
@@ -271,6 +271,7 @@ export type Dictionary = {
     list_not_found: string
     see_your_lists_or_create_new: string
     here: string
+    list_view_link: string
   }
   list_items: {
     table: string


### PR DESCRIPTION
## Describe your changes
Added a button that takes me to the page of my lists, which only appears for the authenticated user and already renders in their lists tab when clicked. To achieve this, I created a client component that opens the tabs of the page, handles the fetches within it, and passes their results as props to my component and subsequently to the components that the shdcn tabs render.

## Issue ticket number and link
#172
PLO-52

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it's an essential feature, I've tested it thoroughly.
- [ ] Do we need to implement analytics?
- [x] Will this be part of a product update? If yes, please write one phrase about this update.

a button who leads the user from the all lists page to the own lists page

Preview:
![image](https://github.com/plotwist-app/plotwist/assets/145717927/0082de3b-402f-4d83-8acd-0fe1ce6d4e99)


