### PR TITLE
feat: explore popular lists link

### DIFF
--- a/apps/web/public/dictionaries/de-DE.json
+++ b/apps/web/public/dictionaries/de-DE.json
@@ -627,7 +627,8 @@
     "lists": "Listen",
     "communities": "Gemeinschaften",
     "work_in_progress": "In Bearbeitung",
-    "no_lists": "Dieser Benutzer hat noch keine Listen."
+    "no_lists": "Dieser Benutzer hat noch keine Listen.",
+    "explore_popular_lists": "Klicken Sie hier, um die beliebtesten Listen zu erkunden"
   },
   "profile_form": {
     "dialog_title": "Profil bearbeiten",

--- a/apps/web/public/dictionaries/en-US.json
+++ b/apps/web/public/dictionaries/en-US.json
@@ -628,7 +628,8 @@
     "lists": "Lists",
     "communities": "Communities",
     "work_in_progress": "Work in progress",
-    "no_lists": "This user has no lists yet."
+    "no_lists": "This user has no lists yet.",
+    "explore_popular_lists": "Click here to explore the most popular lists"
   },
   "profile_form": {
     "dialog_title": "Edit profile",

--- a/apps/web/public/dictionaries/es-ES.json
+++ b/apps/web/public/dictionaries/es-ES.json
@@ -627,7 +627,8 @@
     "lists": "Listas",
     "communities": "Comunidades",
     "work_in_progress": "En progreso",
-    "no_lists": "Este usuario aún no tiene listas."
+    "no_lists": "Este usuario aún no tiene listas.",
+    "explore_popular_lists": "Haga clic aquí para explorar las listas más populares"
   },
   "profile_form": {
     "dialog_title": "Editar perfil",

--- a/apps/web/public/dictionaries/fr-FR.json
+++ b/apps/web/public/dictionaries/fr-FR.json
@@ -628,7 +628,8 @@
     "lists": "Listes",
     "communities": "Communautés",
     "work_in_progress": "Travail en cours",
-    "no_lists": "Cet utilisateur n'a pas encore de listes."
+    "no_lists": "Cet utilisateur n'a pas encore de listes.",
+    "explore_popular_lists": "Cliquez ici pour explorer les listes les plus populaires"
   },
   "profile_form": {
     "dialog_title": "Modifier le profil",

--- a/apps/web/public/dictionaries/it-IT.json
+++ b/apps/web/public/dictionaries/it-IT.json
@@ -628,7 +628,8 @@
     "lists": "Liste",
     "communities": "Comunità",
     "work_in_progress": "Lavoro in corso",
-    "no_lists": "Questo utente non ha ancora liste."
+    "no_lists": "Questo utente non ha ancora liste.",
+    "explore_popular_lists": "Clicca qui per esplorare le liste più popolari"
   },
   "profile_form": {
     "dialog_title": "Modifica profilo",

--- a/apps/web/public/dictionaries/ja-JP.json
+++ b/apps/web/public/dictionaries/ja-JP.json
@@ -627,7 +627,8 @@
     "lists": "リスト",
     "communities": "コミュニティ",
     "work_in_progress": "作業中",
-    "no_lists": "このユーザーはまだリストを持っていません。"
+    "no_lists": "このユーザーはまだリストを持っていません。",
+    "explore_popular_lists": "ここをクリックして人気のリストを探す"
   },
   "profile_form": {
     "dialog_title": "プロフィール編集",

--- a/apps/web/public/dictionaries/pt-BR.json
+++ b/apps/web/public/dictionaries/pt-BR.json
@@ -627,7 +627,8 @@
     "lists": "Listas",
     "communities": "Comunidades",
     "work_in_progress": "Em andamento",
-    "no_lists": "Este usuário ainda não possui listas."
+    "no_lists": "Este usuário ainda não possui listas.",
+    "explore_popular_lists": "Clique aqui para explorar as listas mais populares"
   },
 
   "profile_form": {

--- a/apps/web/src/app/[lang]/[username]/_components/profile-lists.tsx
+++ b/apps/web/src/app/[lang]/[username]/_components/profile-lists.tsx
@@ -6,6 +6,7 @@ import { useQuery } from '@tanstack/react-query'
 import { ListForm } from '../../lists/_components/list-form'
 import { useLanguage } from '@/context/language'
 import { fetchListsService } from '@/services/api/lists/fetch-lists'
+import Link from 'next/link'
 
 type ProfileListsProps = {
   userId: string
@@ -36,9 +37,10 @@ export const ProfileLists = ({ userId }: ProfileListsProps) => {
   if (isVisitorAndListEmpty) {
     return (
       <div className="justify flex w-full  flex-col items-center justify-center space-y-1 rounded-md border border-dashed px-4 py-8 text-center">
-        <p className="text-sm text-muted-foreground">
-          {dictionary.profile.no_lists}
-        </p>
+        <p>{dictionary.profile.no_lists}</p>
+        <Link href={`/lists`} className="text-sm text-muted-foreground">
+          {dictionary.profile.explore_popular_lists}
+        </Link>
       </div>
     )
   }

--- a/apps/web/src/utils/dictionaries/get-dictionaries.types.ts
+++ b/apps/web/src/utils/dictionaries/get-dictionaries.types.ts
@@ -615,6 +615,7 @@ export type Dictionary = {
     communities: string
     work_in_progress: string
     no_lists: string
+    explore_popular_lists: string
   }
   profile_form: {
     dialog_title: string


### PR DESCRIPTION
## Describe your changes
If the user accesses another's page and they are not the owner of that profile, the message displayed would be 'the user does not have any lists yet' where a link with 'Click here to explore the most popular lists' was also added.


## Issue ticket number and link
PLO-54
#179

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it's an essential feature, I've tested it thoroughly.
- [ ] Do we need to implement analytics?
- [x] Will this be part of a product update? If yes, please write one phrase about this update.

A link was added on the user's lists page, visible to the visitor, to access the most popular lists.

preview:
![image](https://github.com/plotwist-app/plotwist/assets/145717927/e619bf10-ca59-4dea-b737-4acda19cf73d)

