### PR TITLE
fix: profile become pro button translation

### DIFF
--- a/apps/web/public/dictionaries/de-DE.json
+++ b/apps/web/public/dictionaries/de-DE.json
@@ -701,5 +701,6 @@
   "send_to": "Gesendet an",
   "sent_to": "gesendet an",
   "cancel_shipping": "Versand stornieren",
-  "add_to_list": "Zur Liste hinzufügen"
+  "add_to_list": "Zur Liste hinzufügen",
+  "become_pro_button" : "Werden" 
 }

--- a/apps/web/public/dictionaries/en-US.json
+++ b/apps/web/public/dictionaries/en-US.json
@@ -701,5 +701,6 @@
   "sent": "Sent",
   "sent_to": "sent to",
   "cancel_shipping": "Cancel shipping",
-  "add_to_list": "Add to list"
+  "add_to_list": "Add to list",
+  "become_pro_button" : "Become" 
 }

--- a/apps/web/public/dictionaries/es-ES.json
+++ b/apps/web/public/dictionaries/es-ES.json
@@ -700,5 +700,6 @@
   "sent": "Enviadas",
   "sent_to": "envió a",
   "cancel_shipping": "Cancelar envío",
-  "add_to_list": "Añadir a la lista"
+  "add_to_list": "Añadir a la lista",
+  "become_pro_button" : "Convertirse"
 }

--- a/apps/web/public/dictionaries/fr-FR.json
+++ b/apps/web/public/dictionaries/fr-FR.json
@@ -701,5 +701,6 @@
   "sent": "Envoyées",
   "sent_to": "envoyé à",
   "cancel_shipping": "Annuler l'envoi",
-  "add_to_list": "Ajouter à la liste"
+  "add_to_list": "Ajouter à la liste",
+  "become_pro_button" : "Devenir" 
 }

--- a/apps/web/public/dictionaries/it-IT.json
+++ b/apps/web/public/dictionaries/it-IT.json
@@ -701,5 +701,6 @@
   "sent": "Inviate",
   "sent_to": "inviato a",
   "cancel_shipping": "Annulla spedizione",
-  "add_to_list": "Aggiungi alla lista"
+  "add_to_list": "Aggiungi alla lista",
+  "become_pro_button" : "Diventare"
 }

--- a/apps/web/public/dictionaries/ja-JP.json
+++ b/apps/web/public/dictionaries/ja-JP.json
@@ -700,5 +700,6 @@
   "sent": "送信済み",
   "sent_to": "送信先",
   "cancel_shipping": "配送をキャンセル",
-  "add_to_list": "リストに追加"
+  "add_to_list": "リストに追加",
+  "become_pro_button" : "なる"
 }

--- a/apps/web/public/dictionaries/pt-BR.json
+++ b/apps/web/public/dictionaries/pt-BR.json
@@ -701,5 +701,6 @@
   "sent": "Enviadas",
   "sent_to": "enviou para",
   "cancel_shipping": "Cancelar envio",
-  "add_to_list": "Adicionar à lista"
+  "add_to_list": "Adicionar à lista",
+  "become_pro_button" : "Tornar-se"
 }

--- a/apps/web/src/components/header/header-profile.tsx
+++ b/apps/web/src/components/header/header-profile.tsx
@@ -107,7 +107,9 @@ export const HeaderProfile = () => {
                   href={`/${language}/pricing`}
                   className="flex items-center gap-1.5 rounded-md p-2 hover:cursor-pointer hover:bg-muted"
                 >
-                  <p className="ml-1.5 text-sm">Become</p>
+                  <p className="ml-1.5 text-sm">
+                    {dictionary.become_pro_button}
+                  </p>
                   <ProBadge />
                 </Link>
               </DropdownMenuItem>

--- a/apps/web/src/utils/dictionaries/get-dictionaries.types.ts
+++ b/apps/web/src/utils/dictionaries/get-dictionaries.types.ts
@@ -688,4 +688,5 @@ export type Dictionary = {
   sent_to: string
   cancel_shipping: string
   add_to_list: string
+  become_pro_button: string
 }


### PR DESCRIPTION
## Describe your changes
fix the translation to the "become" in the profile button in header

## Issue ticket number and link
PLO-57 https://linear.app/plotwist/issue/PLO-57/improvement-profile-button-in-header
#185 https://github.com/plotwist-app/plotwist/issues/185

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it's an essential feature, I've tested it thoroughly.
- [ ] Do we need to implement analytics?
- [x] Will this be part of a product update? If yes, please write one phrase about this update.

fix the translation to the "become" in the profile button in header
