### PR TITLE
fix(movie): use CommandInput and CommandList (Unhandled Runtime Error…

### DIFF
--- a/apps/web/src/components/movies-list-filters/tabs/filters/(fields)/genres.tsx
+++ b/apps/web/src/components/movies-list-filters/tabs/filters/(fields)/genres.tsx
@@ -14,8 +14,9 @@ import {
 } from '@plotwist/ui/components/ui/form'
 import {
   Command,
-  CommandGroup,
   CommandItem,
+  CommandInput,
+  CommandList
 } from '@plotwist/ui/components/ui/command'
 
 import { useLanguage } from '@/context/language'
@@ -149,7 +150,7 @@ export const GenresField = () => {
                   ))}
                 </div>
 
-                <CommandPrimitive.Input
+                <CommandInput
                   ref={inputRef}
                   value={inputValue}
                   onValueChange={setInputValue}
@@ -165,7 +166,7 @@ export const GenresField = () => {
               <div className="relative mt-2">
                 {open && selectableGenres.length > 0 ? (
                   <div className="absolute top-0 z-10 max-h-[200px] w-full overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md outline-none animate-in md:max-h-none">
-                    <CommandGroup className="h-full overflow-auto">
+                    <CommandList className="h-full overflow-auto">
                       {selectableGenres.map((option) => {
                         return (
                           <CommandItem
@@ -184,7 +185,7 @@ export const GenresField = () => {
                           </CommandItem>
                         )
                       })}
-                    </CommandGroup>
+                    </CommandList>
                   </div>
                 ) : null}
               </div>


### PR DESCRIPTION
## Describe your changes
Change CommandPrimitive.Input to CommandInput and CommandGroup to CommandList in order to fix Unhandled Runtime Error TypeError: undefined is not iterable (cannot read property of Symbole(Symbole.iterator))
## Issue ticket number and link
#219 
## Checklist before requesting a review
- [x ] I have performed a self-review of my code
- [ ] If it's an essential feature, I've tested it thoroughly.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.