### PR TITLE
Fix: Fix Dark/Light Mode Icons and Search Bar Functionality

### DIFF
--- a/apps/web/src/components/command-search/command-search.tsx
+++ b/apps/web/src/components/command-search/command-search.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react'
 import { useDebounce } from '@uidotdev/usehooks'
-import { usePathname } from 'next/navigation'
 import {
   type MovieWithMediaType,
   type TvSerieWithMediaType,
@@ -32,7 +31,6 @@ export const CommandSearch = () => {
   const [open, setOpen] = useState(false)
   const [search, setSearch] = useState('')
   const debouncedSearch = useDebounce(search, 500)
-  const pathName = usePathname()
   const { language, dictionary } = useLanguage()
 
   const { data, isLoading } = useQuery({
@@ -53,10 +51,6 @@ export const CommandSearch = () => {
     document.addEventListener('keydown', down)
     return () => document.removeEventListener('keydown', down)
   }, [])
-
-  useEffect(() => {
-    if (open) setOpen(false)
-  }, [pathName, open])
 
   const [movies, tvSeries] = [
     data?.results.filter(

--- a/apps/web/src/components/header/header-navigation-drawer-configs.tsx
+++ b/apps/web/src/components/header/header-navigation-drawer-configs.tsx
@@ -60,9 +60,9 @@ export const HeaderNavigationDrawerConfigs = () => {
                 key={i}
               >
                 {i === 'light' ? (
-                  <MoonStar className="size-4" />
-                ) : (
                   <Sun className="size-4" />
+                ) : (
+                  <MoonStar className="size-4" />
                 )}
               </div>
             )


### PR DESCRIPTION
# This PR addresses two issues related to the UI and search functionality:

## 1. Fix Dark/Light Mode Icons:
The icons for Dark Mode and Light Mode were reversed.
Now, when the user is in Dark Mode, the Dark Mode icon is selected, and vice versa.
Ensured that the toggle behavior is consistent with the displayed icon.

## 2. Resolve Search Bar Not Working:
Fixed the issue where the search bar wasn't opening at all.

## Changes:
Updated the Dark/Light mode toggle logic to correctly match icons with the current theme.
Removed the useEffect in the SearchBar component that was causing the error.

## Screenshots (if applicable):
 - Dark & Light Mode:
     Before:
 
     ![image](https://github.com/user-attachments/assets/abb66d1b-7ffb-4d56-aa7e-09c412d84c29)
 
    After:
 
     ![image](https://github.com/user-attachments/assets/991b4feb-b923-4b05-8351-520500bcb000)

 - SearchBar:
 
 
     ![image](https://github.com/user-attachments/assets/cc01c191-abbf-4da3-8b40-5c0d876093be)


## Testing:
 Manually tested Dark/Light mode toggle to ensure icons are correct.
 Verified that the search bar now works and fetches results correctly.

## Related Issues:
https://github.com/plotwist-app/plotwist/issues/241