### PR TITLE
Fix(lists): Restrict List Order Editing to List Author Only

### DIFF
--- a/apps/web/src/app/[lang]/lists/[id]/_components/list-items/list-items.tsx
+++ b/apps/web/src/app/[lang]/lists/[id]/_components/list-items/list-items.tsx
@@ -24,8 +24,15 @@ export const ListItems = ({ ownerId, listItems }: ListItemsProps) => {
 
   const { user } = useAuth()
 
+  const isListAuthor = ownerId === user?.id
+
   const contentByLayout: Record<typeof layout, JSX.Element> = {
-    grid: <ListItemsGrid listItems={listItems} isEditable={isEditable} />,
+    grid: (
+      <ListItemsGrid
+        listItems={listItems}
+        isEditable={!isListAuthor ? false : isEditable}
+      />
+    ),
     table: (
       <DataTable
         data={listItems}
@@ -33,8 +40,6 @@ export const ListItems = ({ ownerId, listItems }: ListItemsProps) => {
       />
     ),
   }
-
-  const isListAuthor = ownerId === user?.id
 
   return (
     <section className="space-y-4">

--- a/apps/web/src/app/[lang]/lists/[id]/_components/list-items/list-items.tsx
+++ b/apps/web/src/app/[lang]/lists/[id]/_components/list-items/list-items.tsx
@@ -10,15 +10,19 @@ import { ListItemsGrid } from './list-items-grid'
 import { DataTable, columns } from '../data-table'
 import { useListMode } from '@/context/list-mode'
 import { useState } from 'react'
+import { useAuth } from '@/context/auth'
 
 type ListItemsProps = {
+  ownerId: string
   listItems: ListItem[]
 }
-export const ListItems = ({ listItems }: ListItemsProps) => {
+export const ListItems = ({ ownerId, listItems }: ListItemsProps) => {
   const [layout, setLayout] = useState<'table' | 'grid'>('grid')
   const { dictionary, language } = useLanguage()
   const { mode } = useListMode()
   const [isEditable, setIsEditable] = useState(false)
+
+  const { user } = useAuth()
 
   const contentByLayout: Record<typeof layout, JSX.Element> = {
     grid: <ListItemsGrid listItems={listItems} isEditable={isEditable} />,
@@ -29,6 +33,8 @@ export const ListItems = ({ listItems }: ListItemsProps) => {
       />
     ),
   }
+
+  const isListAuthor = ownerId === user?.id
 
   return (
     <section className="space-y-4">
@@ -53,7 +59,11 @@ export const ListItems = ({ listItems }: ListItemsProps) => {
           </Button>
         </div>
         {layout === 'grid' && (
-          <Button variant={'ghost'} onClick={() => setIsEditable(!isEditable)}>
+          <Button
+            variant="outline"
+            onClick={() => setIsEditable(!isEditable)}
+            disabled={!isListAuthor}
+          >
             {isEditable ? dictionary.save_order : dictionary.edit_order}
           </Button>
         )}

--- a/apps/web/src/app/[lang]/lists/[id]/page.tsx
+++ b/apps/web/src/app/[lang]/lists/[id]/page.tsx
@@ -110,7 +110,7 @@ const ListPage = ({ params: { id } }: ListPageProps) => {
                 </p>
               </div>
 
-              <ListItems listItems={list.list_items} />
+              <ListItems listItems={list.list_items} ownerId={list.user_id} />
             </div>
 
             <div className="col-span-1 space-y-4">

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { RotateCw } from 'lucide-react'
 import { cn } from '@plotwist/ui/lib/utils'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
   {
     variants: {
       variant: {


### PR DESCRIPTION
# This PR resolves the issue where any user could edit the order of items in a list, regardless of authorship. Now, only the list author has the ability to modify the list's item order.

## Changes:
Added a check to ensure that only the list author can access the drag-and-drop feature or reorder items.
Non-authors can still view the list, but editing capabilities are disabled for them.

## UI Changes:

The UI for non-authors will still show the edit order button, but in the disabled state.

Testing:
 Verified that list authors can still reorder items in their own lists.
 Tested that non-authors can view lists but cannot reorder them.

## Screenshots:

Before: 
![image](https://github.com/user-attachments/assets/08f88160-b4dc-4aba-9d92-904d447a5afe)

After:
![image](https://github.com/user-attachments/assets/704d06ae-dd65-47a8-af19-857b9703b374)


Related Issues:

https://github.com/plotwist-app/plotwist/issues/243