### PR TITLE
feat(Legacy Modal): add dictionaries to legacy user modal

### DIFF
--- a/apps/web/public/dictionaries/de-DE.json
+++ b/apps/web/public/dictionaries/de-DE.json
@@ -594,6 +594,12 @@
     "title": "Likes",
     "view_profile": "Profil anzeigen"
   },
+  "legacy_user": {
+    "title": "Passwort zurücksetzen",
+    "description": "Wir haben unser System aktualisiert und aus Sicherheitsgründen ist es notwendig, Ihr Passwort zurückzusetzen. Wir haben Anweisungen an Ihre registrierte E-Mail-Adresse gesendet.",
+    "resend_email": "E-Mail erneut senden",
+    "agree": "Verstanden"
+  },
   "access_button": "Zugreifen",
   "access_now": "Jetzt zugreifen",
   "create_account": "Benutzerkonto erstellen",

--- a/apps/web/public/dictionaries/de-DE.json
+++ b/apps/web/public/dictionaries/de-DE.json
@@ -597,7 +597,7 @@
   "legacy_user": {
     "title": "Passwort zurücksetzen",
     "description": "Wir haben unser System aktualisiert und aus Sicherheitsgründen ist es notwendig, Ihr Passwort zurückzusetzen. Wir haben Anweisungen an Ihre registrierte E-Mail-Adresse gesendet.",
-    "resend_email": "E-Mail erneut senden",
+    "resend_email": "Email erneut senden",
     "agree": "Verstanden"
   },
   "access_button": "Zugreifen",

--- a/apps/web/public/dictionaries/en-US.json
+++ b/apps/web/public/dictionaries/en-US.json
@@ -592,6 +592,12 @@
     "title": "Likes",
     "view_profile": "View profile"
   },
+  "legacy_user": {
+    "title": "Password Reset",
+    "description": "We have updated our system, and for your security, it's necessary to reset your password. We have sent instructions to your registered email.",
+    "resend_email": "Resend Email",
+    "agree": "Got it"
+  },
   "access_button": "Access",
   "access_now": "Access now",
   "create_account": "Create account",

--- a/apps/web/public/dictionaries/es-ES.json
+++ b/apps/web/public/dictionaries/es-ES.json
@@ -591,6 +591,12 @@
     "title": "Gustos",
     "view_profile": "Ver perfil"
   },
+  "legacy_user": {
+    "title": "Restablecimiento de contraseña",
+    "description": "Hemos actualizado nuestro sistema y, por tu seguridad, es necesario restablecer tu contraseña. Hemos enviado instrucciones a tu correo electrónico registrado.",
+    "resend_email": "Reenviar correo electrónico",
+    "agree": "Entendido"
+  },
   "access_button": "Acceder",
   "access_now": "Accede ahora",
   "create_account": "Crear una cuenta",

--- a/apps/web/public/dictionaries/fr-FR.json
+++ b/apps/web/public/dictionaries/fr-FR.json
@@ -592,6 +592,12 @@
     "title": "Aime",
     "view_profile": "Voir le profil"
   },
+  "legacy_user": {
+    "title": "Réinitialisation du mot de passe",
+    "description": "Nous avons mis à jour notre système et, pour votre sécurité, il est nécessaire de réinitialiser votre mot de passe. Nous avons envoyé des instructions à votre adresse e-mail enregistrée.",
+    "resend_email": "Renvoyer l'e-mail",
+    "agree": "J'ai compris"
+  },
   "access_button": "Accéder",
   "access_now": "Accede ahora",
   "create_account": "Crear una cuenta",

--- a/apps/web/public/dictionaries/it-IT.json
+++ b/apps/web/public/dictionaries/it-IT.json
@@ -591,6 +591,12 @@
     "title": "Piace",
     "view_profile": "Vedi profilo"
   },
+  "legacy_user": {
+    "title": "Reimpostazione della password",
+    "description": "Abbiamo aggiornato il nostro sistema e, per la tua sicurezza, è necessario reimpostare la password. Abbiamo inviato le istruzioni alla tua e-mail registrata.",
+    "resend_email": "Reinvia e-mail",
+    "agree": "Ho capito"
+  },
   "access_button": "Accedi",
   "access_now": "Accedi ora",
   "create_account": "Creare un account",

--- a/apps/web/public/dictionaries/ja-JP.json
+++ b/apps/web/public/dictionaries/ja-JP.json
@@ -591,6 +591,12 @@
     "title": "いいね！",
     "view_profile": "プロフィールを見る"
   },
+  "legacy_user": {
+    "title": "パスワードの再設定",
+    "description": "システムを更新しました。セキュリティのため、パスワードを再設定する必要があります。登録されたメールアドレスに手順を送信しました。",
+    "resend_email": "メールを再送信",
+    "agree": "了解しました"
+  },
   "access_button": "アクセス",
   "access_now": "今すぐアクセス",
   "create_account": "アカウントを作成する",

--- a/apps/web/public/dictionaries/pt-BR.json
+++ b/apps/web/public/dictionaries/pt-BR.json
@@ -591,6 +591,12 @@
     "title": "Curtidas",
     "view_profile": "Ver perfil"
   },
+  "legacy_user": {
+    "title": "Redefinição de senha",
+    "description": "Atualizamos nosso sistema e, para sua segurança, é necessário redefinir sua senha. Enviamos instruções para o seu e-mail registrado.",
+    "resend_email": "Reenviar e-mail",
+    "agree": "Entendi"
+  },
   "access_button": "Acessar",
   "access_now": "Acesse agora",
   "create_account": "Criar conta",

--- a/apps/web/src/actions/auth/sign-up.ts
+++ b/apps/web/src/actions/auth/sign-up.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { PostUsersCreateBody } from '@/api/endpoints.schemas'
+import type { PostUsersCreateBody } from '@/api/endpoints.schemas'
 import { postUsersCreate } from '@/api/users'
 import { signIn } from './sign-in'
 

--- a/apps/web/src/api/users.ts
+++ b/apps/web/src/api/users.ts
@@ -47,7 +47,7 @@ import { axiosInstance } from '../services/axios-instance'
  */
 export const postUsersCreate = (postUsersCreateBody: PostUsersCreateBody) => {
   return axiosInstance<PostUsersCreate201>({
-    url: `/users/create`,
+    url: '/users/create',
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     data: postUsersCreateBody,
@@ -120,7 +120,7 @@ export const getUsersAvailableUsername = (
   signal?: AbortSignal,
 ) => {
   return axiosInstance<GetUsersAvailableUsername200>({
-    url: `/users/available-username`,
+    url: '/users/available-username',
     method: 'GET',
     params,
     signal,
@@ -130,7 +130,7 @@ export const getUsersAvailableUsername = (
 export const getGetUsersAvailableUsernameQueryKey = (
   params: GetUsersAvailableUsernameParams,
 ) => {
-  return [`/users/available-username`, ...(params ? [params] : [])] as const
+  return ['/users/available-username', ...(params ? [params] : [])] as const
 }
 
 export const getGetUsersAvailableUsernameQueryOptions = <
@@ -378,7 +378,7 @@ export const getUsersAvailableEmail = (
   signal?: AbortSignal,
 ) => {
   return axiosInstance<GetUsersAvailableEmail200>({
-    url: `/users/available-email`,
+    url: '/users/available-email',
     method: 'GET',
     params,
     signal,
@@ -388,7 +388,7 @@ export const getUsersAvailableEmail = (
 export const getGetUsersAvailableEmailQueryKey = (
   params: GetUsersAvailableEmailParams,
 ) => {
-  return [`/users/available-email`, ...(params ? [params] : [])] as const
+  return ['/users/available-email', ...(params ? [params] : [])] as const
 }
 
 export const getGetUsersAvailableEmailQueryOptions = <
@@ -1128,11 +1128,11 @@ export function useGetUserByIdSuspense<
  * Get me
  */
 export const getMe = (signal?: AbortSignal) => {
-  return axiosInstance<GetMe200>({ url: `/me`, method: 'GET', signal })
+  return axiosInstance<GetMe200>({ url: '/me', method: 'GET', signal })
 }
 
 export const getGetMeQueryKey = () => {
-  return [`/me`] as const
+  return ['/me'] as const
 }
 
 export const getGetMeQueryOptions = <
@@ -1299,7 +1299,7 @@ export function useGetMeSuspense<
  */
 export const patchUser = (patchUserBody: PatchUserBody) => {
   return axiosInstance<PatchUser200>({
-    url: `/user`,
+    url: '/user',
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     data: patchUserBody,
@@ -1366,7 +1366,7 @@ export const patchUserPassword = (
   patchUserPasswordBody: PatchUserPasswordBody,
 ) => {
   return axiosInstance<PatchUserPassword200>({
-    url: `/user/password`,
+    url: '/user/password',
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     data: patchUserPasswordBody,

--- a/apps/web/src/app/[lang]/sign-in/_sign-in-form.tsx
+++ b/apps/web/src/app/[lang]/sign-in/_sign-in-form.tsx
@@ -24,10 +24,10 @@ import { Input } from '@plotwist/ui/components/ui/input'
 
 import { useLanguage } from '@/context/language'
 
-import { Dictionary } from '@/utils/dictionaries'
+import type { Dictionary } from '@/utils/dictionaries'
 import { z } from 'zod'
 import { toast } from 'sonner'
-import { signIn } from '@/actions/auth/sign-in'
+import type { signIn } from '@/actions/auth/sign-in'
 import {
   Dialog,
   DialogFooter,
@@ -166,17 +166,15 @@ export const SignInForm = ({ onSignIn }: SignInFormProps) => {
 
       <Dialog open={warningDialogOpen} onOpenChange={setWarningDialogOpen}>
         <DialogContent>
-          <DialogTitle>Redefinição de senha</DialogTitle>
+          <DialogTitle>{dictionary.legacy_user.title}</DialogTitle>
 
-          <p>
-            Atualizamos nosso sistema e, para sua segurança, é necessário
-            redefinir sua senha. Enviamos instruções para o seu e-mail
-            registrado.
-          </p>
+          <p>{dictionary.legacy_user.description}</p>
 
           <DialogFooter>
-            <Button variant="outline">Reenviar e-mail</Button>
-            <Button>Entendi</Button>
+            <Button variant="outline">
+              {dictionary.legacy_user.resend_email}
+            </Button>
+            <Button>{dictionary.legacy_user.agree}</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/apps/web/src/app/[lang]/sign-in/page.tsx
+++ b/apps/web/src/app/[lang]/sign-in/page.tsx
@@ -1,4 +1,4 @@
-import { PageProps } from '@/types/languages'
+import type { PageProps } from '@/types/languages'
 import { getDictionary } from '@/utils/dictionaries'
 import { Pattern } from '@/components/pattern'
 import Link from 'next/link'


### PR DESCRIPTION
## Describe your changes

I've added dictionaries to resend password modal when the users is legacy.

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] If it's an essential feature, I've tested it thoroughly.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.