### PR TITLE
update some translations

### DIFF
--- a/apps/web/public/dictionaries/de-DE.json
+++ b/apps/web/public/dictionaries/de-DE.json
@@ -733,7 +733,7 @@
   "contain_spoilers": "Enthält Spoiler",
   "no_lists_found": "Wir haben keine Listen gefunden.",
   "organize": "Organisieren",
-  "movies_and_series": "Filme und Serien",
+  "movies_and_series": "von Filmen und Serien",
   "never_been_easier": "war noch nie so einfach.",
   "most_apps_functional": "Die meisten Apps sind funktional, aber langweilig.",
   "plotwist_incredible_interface": "Bei Plotwist bevorzugen wir eine unglaubliche Benutzeroberfläche, auch wenn Sie diese Serie auf Ihrer Liste nie ansehen.",

--- a/apps/web/public/dictionaries/en-US.json
+++ b/apps/web/public/dictionaries/en-US.json
@@ -728,7 +728,7 @@
   "watchlist_removed": "Removed from Watchlist!",
   "contain_spoilers": "Contains spoilers",
   "no_lists_found": "We did not find any lists.",
-  "organize": "Organize",
+  "organize": "Organizing",
   "movies_and_series": "movies and series",
   "never_been_easier": "has never been easier.",
   "most_apps_functional": "Most apps are functional, but boring.",

--- a/apps/web/public/dictionaries/fr-FR.json
+++ b/apps/web/public/dictionaries/fr-FR.json
@@ -730,7 +730,7 @@
   "contain_spoilers": "Contient des spoilers",
   "no_lists_found": "Nous n'avons trouvé aucune liste.",
   "organize": "Organiser",
-  "movies_and_series": "films et séries",
+  "movies_and_series": "des films et séries",
   "never_been_easier": "n'a jamais été aussi facile.",
   "most_apps_functional": "La plupart des applications sont fonctionnelles, mais sans intérêt.",
   "plotwist_incredible_interface": "Chez Plotwist, nous préférons une interface incroyable, même si vous ne regardez jamais cette série sur votre liste.",


### PR DESCRIPTION
This pull request includes updates to the translations in the dictionaries for German, English, and French. The changes focus on improving the accuracy and consistency of the translations.

Translation updates:

* [`apps/web/public/dictionaries/de-DE.json`](diffhunk://#diff-f10d1c5b07ae5727025d7934b2b49fe1c4924cfaabd4c381e32f4a78dfa4e6d2L736-R736): Modified the translation for "movies and series" to "von Filmen und Serien" to improve accuracy.
* [`apps/web/public/dictionaries/en-US.json`](diffhunk://#diff-bab5f3a1a5aabd865787da91a0baac86beb5f73965ecacc6f88810c6581a17cdL731-R731): Changed the translation for "organize" to "organizing" for consistency.
* [`apps/web/public/dictionaries/fr-FR.json`](diffhunk://#diff-d066c035d27074b37efd23a6c05e5449ddca77f39d834136b5c4e84c9dd57f56L733-R733): Updated the translation for "movies and series" to "des films et séries" to enhance accuracy.