### PR TITLE
feat: add tooltip to show the exact date some activity had occured

### DIFF
--- a/apps/web/src/app/[lang]/[username]/page.tsx
+++ b/apps/web/src/app/[lang]/[username]/page.tsx
@@ -21,13 +21,19 @@ import {
   ReviewActivity,
   WatchEpisodeActivity,
 } from './_components/user-activities'
-import { formatDistanceToNowStrict } from 'date-fns'
+import { format, formatDistanceToNowStrict } from 'date-fns'
 import { useLanguage } from '@/context/language'
 import { locale } from '@/utils/date/locale'
 import { useInView } from 'react-intersection-observer'
 import { useEffect } from 'react'
 import { v4 } from 'uuid'
 import { Skeleton } from '@plotwist/ui/components/ui/skeleton'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@plotwist/ui/components/ui/tooltip'
 
 export default function ActivityPage() {
   const { userId, avatarUrl, username } = useLayoutContext()
@@ -132,12 +138,25 @@ export default function ActivityPage() {
                 {getLabel()}
               </div>
 
-              <span className="text-muted-foreground text-xs whitespace-nowrap">
-                {formatDistanceToNowStrict(new Date(createdAt), {
-                  addSuffix: false,
-                  locale: locale[language],
-                })}
-              </span>
+              <TooltipProvider delayDuration={100}>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <span className="text-muted-foreground text-xs whitespace-nowrap">
+                      {formatDistanceToNowStrict(new Date(createdAt), {
+                        addSuffix: false,
+                        locale: locale[language],
+                      })}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <span>
+                      {format(new Date(createdAt), 'PPP', {
+                        locale: locale[language],
+                      })}
+                    </span>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </div>
           )
         })}


### PR DESCRIPTION
## Describe your changes

This pull request introduces enhancements to the ActivityPage by adding tooltips and improving date formatting. The key updates include:

Imported a date formatting function format from date-fns.
Integrated tooltip components from @plotwist/ui/components/ui/tooltip.
Implemented tooltips that display the formatted date when hovering over elements, improving the user experience.

`apps/web/src/app/[lang]/[username]/page.tsx`: Imported the format function from date-fns and the tooltip components. ([apps/web/src/app/[lang]/[username]/page.tsxL24-R36](https://github.com/plotwist-app/plotwist/compare/task/PLO-171?expand=1))
`apps/web/src/app/[lang]/[username]/page.tsx`: Implemented tooltips for displaying formatted date on hover, enhancing user interaction. ([apps/web/src/app/[lang]/[username]/page.tsxR141-R159](https://github.com/plotwist-app/plotwist/compare/task/PLO-171?expand=1))

## Issue ticket number and link

https://github.com/plotwist-app/plotwist/issues/364


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it's an essential feature, I've tested it thoroughly.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.