### PR TITLE
Configuração usuários ativos iOS

### DIFF
--- a/apps/ios/Plotwist/Plotwist/Utils/Environment.swift
+++ b/apps/ios/Plotwist/Plotwist/Utils/Environment.swift
@@ -7,7 +7,7 @@ import Foundation
 
 enum Env {
     static func value(for key: String, fallback: String? = nil) -> String {
-        if let value = Bundle.main.infoDictionary?[key] as? String, !value.isEmpty {
+        if let value = Bundle.main.infoDictionary?[key] as? String, !value.isEmpty, !value.contains("$(") {
             return value.trimmingCharacters(in: .whitespacesAndNewlines)
         }
         print("⚠️ [Env] Missing key: '\(key)' in Info.plist")


### PR DESCRIPTION
## Describe your changes

This PR addresses issues preventing accurate active user tracking for the iOS app in PostHog.

Key changes include:
*   **Enhanced Event Properties**: Added `$lib`, `$platform`, `$device_type`, and `$lib_version` to all analytics events to ensure proper segmentation and filtering in PostHog.
*   **Correct User Merging**: Modified the `identify` call to include `$anon_distinct_id`, ensuring anonymous user activity is correctly merged with identified user profiles upon login.
*   **Robust API Key Handling**: Implemented a fallback mechanism in `Environment.swift` and added validation in `AnalyticsService.swift` to handle cases where the `POSTHOG_API_KEY` build variable might not be correctly substituted, preventing events from being rejected.
*   **Profile Properties**: Included `$platform` and `$lib` in user profile properties during `identify` for better user segmentation.

These changes ensure that iOS active users are correctly counted and attributed in PostHog dashboards.

## Issue ticket number and link

N/A

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it's an essential feature, I've tested it thoroughly.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.

---
<p><a href="https://cursor.com/agents?id=bc-85d02c75-b221-4a12-9fc1-ed8aecef6bd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85d02c75-b221-4a12-9fc1-ed8aecef6bd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

