### PR TITLE
fix(backend): hide deleted users from listings

### DIFF
--- a/apps/backend/src/domain/services/reviews/get-reviews.spec.ts
+++ b/apps/backend/src/domain/services/reviews/get-reviews.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { deleteUserService } from '@/domain/services/users/delete-user'
 import { makeReview } from '@/test/factories/make-review'
 import { makeUser } from '@/test/factories/make-user'
 import { getReviewsService } from './get-reviews'
@@ -35,5 +36,37 @@ describe('get reviews', () => {
         expect.objectContaining({ id: secondReview.id }),
       ]),
     })
+  })
+
+  it('should not return reviews from deleted users', async () => {
+    const deletedTmdbId = 240
+
+    const activeUser = await makeUser()
+    const deletedUser = await makeUser()
+
+    const activeReview = await makeReview({
+      userId: activeUser.id,
+      tmdbId: deletedTmdbId,
+      mediaType: MEDIA_TYPE,
+    })
+
+    const deletedUserReview = await makeReview({
+      userId: deletedUser.id,
+      tmdbId: deletedTmdbId,
+      mediaType: MEDIA_TYPE,
+    })
+
+    await deleteUserService(deletedUser.id)
+
+    const sut = await getReviewsService({
+      tmdbId: deletedTmdbId,
+      mediaType: MEDIA_TYPE,
+      interval: 'ALL_TIME',
+    })
+
+    const reviewIds = sut.reviews.map(review => review.id)
+
+    expect(reviewIds).toContain(activeReview.id)
+    expect(reviewIds).not.toContain(deletedUserReview.id)
   })
 })

--- a/apps/backend/src/infra/db/repositories/followers-repository.ts
+++ b/apps/backend/src/infra/db/repositories/followers-repository.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, getTableColumns, lte, sql } from 'drizzle-orm'
+import { and, desc, eq, getTableColumns, isNull, lte, sql } from 'drizzle-orm'
 import type { CreateFollowServiceInput } from '@/domain/services/follows/create-follow'
 import type { DeleteFollowServiceInput } from '@/domain/services/follows/delete-follow'
 import type { GetFollowServiceInput } from '@/domain/services/follows/get-follow'
@@ -76,11 +76,16 @@ export async function selectFollowers({
         followerId ? eq(schema.followers.followerId, followerId) : undefined
       )
     )
-    .leftJoin(
+    .innerJoin(
       schema.users,
-      eq(
-        followedId ? schema.followers.followerId : schema.followers.followedId,
-        schema.users.id
+      and(
+        eq(
+          followedId
+            ? schema.followers.followerId
+            : schema.followers.followedId,
+          schema.users.id
+        ),
+        isNull(schema.users.deletedAt)
       )
     )
     .leftJoin(

--- a/apps/backend/src/infra/db/repositories/likes-repository.ts
+++ b/apps/backend/src/infra/db/repositories/likes-repository.ts
@@ -1,4 +1,4 @@
-import { eq, getTableColumns, sql } from 'drizzle-orm'
+import { and, eq, getTableColumns, isNull, sql } from 'drizzle-orm'
 import type { InsertLike } from '@/domain/entities/likes'
 import { db } from '..'
 import { schema } from '../schema'
@@ -24,7 +24,13 @@ export async function selectLikes(entityId: string) {
     })
     .from(schema.likes)
     .where(eq(schema.likes.entityId, entityId))
-    .leftJoin(schema.users, eq(schema.likes.userId, schema.users.id))
+    .innerJoin(
+      schema.users,
+      and(
+        eq(schema.likes.userId, schema.users.id),
+        isNull(schema.users.deletedAt)
+      )
+    )
     .leftJoin(
       schema.subscriptions,
       eq(schema.users.id, schema.subscriptions.userId)

--- a/apps/backend/src/infra/db/repositories/list-repository.ts
+++ b/apps/backend/src/infra/db/repositories/list-repository.ts
@@ -1,4 +1,12 @@
-import { and, desc, eq, getTableColumns, isNotNull, sql } from 'drizzle-orm'
+import {
+  and,
+  desc,
+  eq,
+  getTableColumns,
+  isNotNull,
+  isNull,
+  sql,
+} from 'drizzle-orm'
 import type { InsertListModel } from '@/domain/entities/lists'
 import type { GetListsInput } from '@/domain/services/lists/get-lists'
 import type { UpdateListValues } from '@/domain/services/lists/update-list'
@@ -52,7 +60,13 @@ export function selectLists({
         hasBanner ? isNotNull(schema.lists.bannerUrl) : undefined
       )
     )
-    .leftJoin(schema.users, eq(schema.lists.userId, schema.users.id))
+    .innerJoin(
+      schema.users,
+      and(
+        eq(schema.lists.userId, schema.users.id),
+        isNull(schema.users.deletedAt)
+      )
+    )
     .leftJoin(schema.listItems, eq(schema.listItems.listId, schema.lists.id))
     .groupBy(schema.lists.id, schema.users.id)
     .orderBy(desc(schema.lists.createdAt))

--- a/apps/backend/src/infra/db/repositories/recommendations-repository.ts
+++ b/apps/backend/src/infra/db/repositories/recommendations-repository.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq } from 'drizzle-orm'
+import { and, desc, eq, isNull } from 'drizzle-orm'
 import { db } from '..'
 import { schema } from '../schema'
 
@@ -38,9 +38,12 @@ export async function selectReceivedRecommendations(userId: string) {
         eq(schema.recommendations.status, 'PENDING')
       )
     )
-    .leftJoin(
+    .innerJoin(
       schema.users,
-      eq(schema.recommendations.fromUserId, schema.users.id)
+      and(
+        eq(schema.recommendations.fromUserId, schema.users.id),
+        isNull(schema.users.deletedAt)
+      )
     )
     .orderBy(desc(schema.recommendations.createdAt))
 }

--- a/apps/backend/src/infra/db/repositories/review-replies-repository.ts
+++ b/apps/backend/src/infra/db/repositories/review-replies-repository.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, getTableColumns, sql } from 'drizzle-orm'
+import { and, asc, eq, getTableColumns, isNull, sql } from 'drizzle-orm'
 import type { InsertReviewReplyModel } from '@/domain/entities/review-reply'
 import { db } from '@/infra/db'
 import { schema } from '@/infra/db/schema'
@@ -62,6 +62,12 @@ export async function selectReviewReplies(
     })
     .from(schema.reviewReplies)
     .where(eq(schema.reviewReplies.reviewId, reviewId))
-    .leftJoin(schema.users, eq(schema.reviewReplies.userId, schema.users.id))
+    .innerJoin(
+      schema.users,
+      and(
+        eq(schema.reviewReplies.userId, schema.users.id),
+        isNull(schema.users.deletedAt)
+      )
+    )
     .orderBy(asc(schema.reviewReplies.createdAt))
 }

--- a/apps/backend/src/infra/db/repositories/reviews-repository.ts
+++ b/apps/backend/src/infra/db/repositories/reviews-repository.ts
@@ -5,6 +5,7 @@ import {
   eq,
   getTableColumns,
   gte,
+  isNull,
   lte,
   type SQL,
   sql,
@@ -116,7 +117,13 @@ export async function selectReviews({
           : undefined
       )
     )
-    .leftJoin(schema.users, eq(schema.reviews.userId, schema.users.id))
+    .innerJoin(
+      schema.users,
+      and(
+        eq(schema.reviews.userId, schema.users.id),
+        isNull(schema.users.deletedAt)
+      )
+    )
     .orderBy(...orderCriteria)
     .limit(limit + 1)
     .offset(offset)

--- a/apps/backend/src/infra/db/repositories/user-activities.ts
+++ b/apps/backend/src/infra/db/repositories/user-activities.ts
@@ -1,4 +1,13 @@
-import { and, desc, eq, getTableColumns, inArray, lte, sql } from 'drizzle-orm'
+import {
+  and,
+  desc,
+  eq,
+  getTableColumns,
+  inArray,
+  isNull,
+  lte,
+  sql,
+} from 'drizzle-orm'
 import { alias } from 'drizzle-orm/pg-core'
 import type {
   DeleteFollowUserActivity,
@@ -40,7 +49,10 @@ export async function selectUserActivities({
     .leftJoin(schema.lists, buildListsJoinCondition())
     .leftJoin(schema.reviews, buildReviewsJoinCondition())
     .leftJoin(schema.reviewReplies, buildRepliesJoinCondition())
-    .leftJoin(owner, eq(schema.userActivities.userId, owner.id))
+    .innerJoin(
+      owner,
+      and(eq(schema.userActivities.userId, owner.id), isNull(owner.deletedAt))
+    )
 }
 
 function buildAdditionalInfoCase() {
@@ -142,6 +154,9 @@ function buildWhereClause(
 ) {
   return and(
     userIds ? inArray(schema.userActivities.userId, userIds) : undefined,
+    // hide follow activities whose target user was deleted (join above misses)
+    sql`NOT (${schema.userActivities.activityType} IN ('FOLLOW_USER', 'UNFOLLOW_USER')
+      AND ${schema.users.id} IS NULL)`,
     cursor
       ? lte(
           sql`DATE_TRUNC('milliseconds', ${schema.userActivities.createdAt})`,
@@ -153,7 +168,8 @@ function buildWhereClause(
 
 function buildUsersJoinCondition() {
   return sql`(${schema.userActivities.activityType} = 'FOLLOW_USER' OR ${schema.userActivities.activityType} = 'UNFOLLOW_USER') 
-    AND ${sql`(metadata::jsonb->>'followedId')`} = ${schema.users.id}::text`
+    AND ${sql`(metadata::jsonb->>'followedId')`} = ${schema.users.id}::text
+    AND ${schema.users.deletedAt} IS NULL`
 }
 
 function buildListsJoinCondition() {


### PR DESCRIPTION
## Describe your changes

Account deletion is a **soft** delete: `deleteUser` sets `deletedAt` and rewrites the username to `deleted_<uuid>`, keeping the row. Every listing query still joined `users` without filtering `deletedAt`, so the anonymized handle leaked into the UI — e.g. a review signed `deleted_b8ac47655ca344abaa16debbcd959200` on https://plotwist.app/en-US/movies/157336.

This turns those `leftJoin(users)` into `innerJoin` filtered by `isNull(users.deletedAt)`, so rows owned by a deleted user are dropped from the listing:

| Repository | Surface |
|---|---|
| `reviews-repository.ts` | reviews on media pages |
| `review-replies-repository.ts` | replies |
| `likes-repository.ts` | who-liked list |
| `followers-repository.ts` | followers / following |
| `recommendations-repository.ts` | received recommendations |
| `list-repository.ts` | public lists |
| `user-activities.ts` | activity feed (activity owner + `FOLLOW_USER` target) |

Backend only — no API contract change, so web and iOS are both covered without client work.

**How it was verified**

- New regression test in `get-reviews.spec.ts` (testcontainers, real Postgres): fails on `main`, passes with the fix.
- Manual end-to-end against a local server: two users review the same movie, one deletes the account (`DELETE /user`) → before the fix `GET /reviews` returns `deleted_bcd680b5b76e4baabd62f087b4a170e8`, after the fix only the active user's review is listed. Same check done for `GET /review-replies`. Review rows stay in the database — this only hides them.

**Note for reviewers:** #520 lists three other approaches (generic "Deleted user" label, hard delete, mixed). This PR implements the "hide" option since it needs no client or i18n work; happy to switch if you prefer another. Not covered here: `likeCount` / `replyCount` still count interactions made *by* deleted users, and the nested `author` subqueries in `buildReviewInfo` / `buildReplyInfo`.

## Issue ticket number and link

Closes #520 — https://github.com/plotwist-app/plotwist/issues/520

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it's an essential feature, I've tested it thoroughly.
- [ ] Do we need to implement analytics? — No.
- [x] Will this be part of a product update? If yes, please write one phrase about this update.
  - Reviews and activity from deleted accounts no longer show up as `deleted_<id>` across the app.
